### PR TITLE
refactor: Remove unnecessary "as any"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ JWTOption<Name, Schema>) => {
     const validator = schema
         ? getSchemaValidator(
               t.Union([
-                  schema as any,
+                  schema,
                   t.Object({
                       iss: t.Optional(t.String()),
                       sub: t.Optional(t.String()),
@@ -115,7 +115,7 @@ JWTOption<Name, Schema>) => {
                       exp: t.Optional(t.Union([t.String(), t.Number()])),
                       iat: t.Optional(t.String())
                   })
-              ]) as any,
+              ]),
               {}
           )
         : undefined


### PR DESCRIPTION
`as any` should be always considered as a bad practice. Besides, I do not find any compilation error even with `as any` removed.