### PR TITLE
style: Reformat CHANGELOG with Markdownlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,63 @@
+# Changelog
 
-# 0.6.0 - 6 Aug 2023
+## 0.6.0 - 6 Aug 2023
+
 - Add support for Elysia 0.6
 
+## 0.6.0-rc.0 - 6 Aug 2023
 
-# 0.6.0-rc.0 - 6 Aug 2023
 - Add support for Elysia 0.6
-# 0.5.0 - 15 May 2023
+
+## 0.5.0 - 15 May 2023
+
 - Add support for Elysia 0.5
 - Add CommonJS support
 
-# 0.3.0 - 29 Mar 2023
+## 0.3.0 - 29 Mar 2023
+
 Fix:
+
 - Update to support Elysia 0.3
 
-# 0.2.1 - 17 Feb 2023
+## 0.2.1 - 17 Feb 2023
+
 Fix:
+
 - JWT namespace wrong infer type
 
-# 0.2.0 - 17 Feb 2023
+## 0.2.0 - 17 Feb 2023
+
 Improvement:
+
 - Add support for Elysia >= 0.2.0
 
-# 0.1.0-rc.4 - 19 Dec 2022
+## 0.1.0-rc.4 - 19 Dec 2022
+
 Improvement:
+
 - Make `name` optional
 
-# 0.1.0-rc.3 - 13 Dec 2022
+## 0.1.0-rc.3 - 13 Dec 2022
+
 Improvement:
+
 - Add support for Elysia 0.1.0-rc.5
 
-# 0.1.0-rc.2 - 9 Dec 2022
+## 0.1.0-rc.2 - 9 Dec 2022
+
 Fix:
+
 - Add main fields Bundlephobia
 
-# 0.1.0-rc.1 - 6 Dec 2022
+## 0.1.0-rc.1 - 6 Dec 2022
+
 Improvement:
+
 - Support for Elysia 0.1.0-rc.1 onward
 
-# 0.0.0-experimental.1 - 30 Oct 2022
+## 0.0.0-experimental.1 - 30 Oct 2022
+
 Change:
+
 - Support for KingWorld 0.0.0-experimental.28 onward
 - chore: update dependencies


### PR DESCRIPTION
Markdownlint is a well-known standard of writing
a Markdown file. This PR reformats the README with
Markdownlint for better readability and less warnings.

This commit also fixes the all-H1 issue by adding
a "# Changelog" heading and turns all the version
history to H2.
