### PR TITLE
refactor: Meaningful type import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,9 @@ module.exports = {
         "@typescript-eslint"
     ],
     "rules": {
+        "@typescript-eslint/consistent-type-imports": ["error", {
+            "prefer": "type-imports",
+        }],
         "@typescript-eslint/ban-types": 'off',
         '@typescript-eslint/no-explicit-any': 'off'
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,6 +99,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+
+    "verbatimModuleSyntax": true
   },
   // "include": ["src/**/*"]
 }


### PR DESCRIPTION
"import type" without enabling "verbatimModuleSyntax"
is meaningless according to TypeScript's documentation[^1].
TypeScript can detect and remove the unused imports
automatically based on its set of rules.

However, being verbose and accurate is not a bad thing.
This commit enables "verbatimModuleSyntax" and
"consistent-type-imports" rules, so we can declare our
imports more exactly.

[^1]: https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax
