### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @elysiajs/static
+# @elysiajs/jwt
 
 Plugin for [Elysia](https://github.com/elysiajs/elysia) for using JWT Authentication.
 


### PR DESCRIPTION
Fix package name typo on the README