### PR TITLE
Fix: `exp` type & overriding default `exp` value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export interface JWTPayloadSpec {
     aud?: string | string[]
     jti?: string
     nbf?: number
-    exp?: number
+    exp?: number | string
     iat?: number
 }
 
@@ -145,6 +145,7 @@ JWTOption<Name, Schema>) => {
 
             if (nbf) jwt = jwt.setNotBefore(nbf)
             if (exp) jwt = jwt.setExpirationTime(exp)
+            if (morePayload.exp) jwt = jwt.setExpirationTime(morePayload.exp)
 
             return jwt.sign(key)
         },


### PR DESCRIPTION
Technically, jose supports passing timey strings, e.g. `'1h'`, `'10days'` etc. ([here](https://github.com/panva/jose/blob/main/src/lib/secs.ts))
This PR updates the type of `exp` to be `string` as well as a `number` for that.

Also, this fixes overriding `exp` value when calling `jwt.sign()` method.
Example:
```typescript
const token = await jwt.sign({
  userId: 'qwbfo21b9d',
  exp: '1h', // <~ this now works fine. Previously this was ignored and threw a type error
})
```