### PR TITLE
allow paylod complex data structures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ JWTOption<Name, Schema>) => {
         }
     }).decorate(name as Name extends string ? Name : 'jwt', {
         sign: (
-            morePayload: UnwrapSchema<Schema, Record<string, string | number>> &
+            morePayload: UnwrapSchema<Schema, Record<string, any>> &
                 JWTPayloadSpec
         ) => {
             let jwt = new SignJWT({
@@ -151,7 +151,7 @@ JWTOption<Name, Schema>) => {
         verify: async (
             jwt?: string
         ): Promise<
-            | (UnwrapSchema<Schema, Record<string, string | number>> &
+            | (UnwrapSchema<Schema, Record<string, any>> &
                   JWTPayloadSpec)
             | false
         > => {


### PR DESCRIPTION
Fixes https://github.com/elysiajs/elysia-jwt/issues/20

Updated the type definitions for JWT payloads to allow complex data structures, including arrays and objects, enabling greater flexibility in handling various use cases. This change modifies the type constraints in both the `sign` and `verify` functions from `string | number` to `any`.