### PR TITLE
Fix tests

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,6 @@ import { jwt } from '../src'
 
 import { describe, expect, it } from 'bun:test'
 
-const req = (path: string) => new Request(`http://localhost${path}`)
 const post = (path: string, body = {}) =>
     new Request(`http://localhost${path}`, {
         method: 'POST',
@@ -13,8 +12,8 @@ const post = (path: string, body = {}) =>
         body: JSON.stringify(body)
     })
 
-describe('Static Plugin', () => {
-    it('sign JWT', async () => {
+describe('JWT Plugin', () => {
+    it('signs and verifies JWTs', async () => {
         const app = new Elysia()
             .use(
                 jwt({
@@ -22,25 +21,27 @@ describe('Static Plugin', () => {
                     secret: 'A'
                 })
             )
-            .post('/validate', ({ jwt, body }) => jwt.sign(body), {
-                body: t.Object({
-                    name: t.String()
-                })
-            })
-            .post('/validate', ({ jwt, body: { name } }) => jwt.verify(name), {
+            .post('/sign', ({ jwt, body }) => jwt.sign(body), {
                 body: t.Object({ name: t.String() })
+            })
+            .post('/verify', ({ jwt, body: { token } }) => jwt.verify(token), {
+                body: t.Object({ token: t.String() })
             })
 
         const name = 'Shirokami'
 
-        const _sign = post('/sign', { name })
-        const token = await _sign.text()
+        const sign = await app.handle(post('/sign', { name }))
+        const token = await sign.text()
+        expect(token).toMatch(/^[A-Za-z0-9_-]{2,}(?:\.[A-Za-z0-9_-]{2,}){2}$/)
 
-        const _verified = post('/verify', { name })
-        const signed = (await _verified.json()) as {
-            name: string
-        }
+        const verify = await app.handle(post('/verify', { token }))
+        const signed = (await verify.json()) as { name: string } | false
+        expect(signed).toEqual({ name });
 
-        expect(name).toBe(signed.name)
+        const verifyForged = await app.handle(post("/verify", {
+            token: "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiU2hpcm9rYW1pIn0.SNUb0H5gYTJYPznYxN36glyJAubUelp8zxy53hYeUt4"
+        }));
+        const forged = (await verifyForged.json()) as { name: string } | false
+        expect(forged).toBe(false);
     })
 })


### PR DESCRIPTION
The `index.test.ts` file appears to test this package, but it does not currently call `jwt.sign` or `jwt.verify`! The test `app` is never used, and assertions are being run on the test `Request`s, not any `Response`s returned from the test app.

This adds the missing `await app.handle(…)` calls, and fixes other issues in the app and test definitions.

I also included a new case – an otherwise-valid JWT generated with a different `secret`, to make sure that fails verification.

```
test/index.test.ts:
✓ JWT Plugin > signs and verifies JWTs [9.33ms]

 1 pass
 0 fail
 3 expect() calls
```