### PR TITLE
Fix/jwt iat type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,11 +109,11 @@ JWTOption<Name, Schema>) => {
 						jti: t.Optional(t.String()),
 						nbf: t.Optional(t.Union([t.String(), t.Number()])),
 						exp: t.Optional(t.Union([t.String(), t.Number()])),
-						iat: t.Optional(t.String())
+						iat: t.Optional(t.Union([t.String(), t.Number()]))
 					})
 				]),
 				{}
-			)
+		  )
 		: undefined
 
 	return new Elysia({

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ JWTOption<Name, Schema>) => {
 					})
 				]),
 				{}
-		  )
+			)
 		: undefined
 
 	return new Elysia({


### PR DESCRIPTION
Type **iat** inconsistency
```
export interface JWTPayloadSpec {
	iss?: string
	sub?: string
	aud?: string | string[]
	jti?: string
	nbf?: number
	exp?: number
	iat?: number
}
```
Schema

```
t.Object({
        iss: t.Optional(t.String()),
        sub: t.Optional(t.String()),
        aud: t.Optional(
	        t.Union([t.String(), t.Array(t.String())])
        ),
        jti: t.Optional(t.String()),
        nbf: t.Optional(t.Union([t.String(), t.Number()])),
        exp: t.Optional(t.Union([t.String(), t.Number()])),
        // change t.Optional(t.String()) -> t.Optional(t.Union([t.String(), t.Number()]))
        iat: t.Optional(t.Union([t.String(), t.Number()]))
})
```


fix #52