### PR TITLE
fix: validation error with `iat`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,8 @@ JWTOption<Name, Schema>) => {
 							t.Union([t.String(), t.Array(t.String())])
 						),
 						jti: t.Optional(t.String()),
-						nbf: t.Optional(t.Union([t.String(), t.Number()])),
-						exp: t.Optional(t.Union([t.String(), t.Number()])),
+						nbf: t.Optional(t.Number()),
+						exp: t.Optional(t.Number()),
 						iat: t.Optional(t.Number())
 					})
 				]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ JWTOption<Name, Schema>) => {
 						jti: t.Optional(t.String()),
 						nbf: t.Optional(t.Union([t.String(), t.Number()])),
 						exp: t.Optional(t.Union([t.String(), t.Number()])),
-						iat: t.Optional(t.String())
+						iat: t.Optional(t.Number())
 					})
 				]),
 				{


### PR DESCRIPTION
Fixes #98

This also fixes a validation error with `iat` that occurred when setting the `schema`.

Also,

If the `payload` returned from `jwtVerify` includes `exp` or `nbf`, those values are generally expected to be numbers—just like `iat`.

Since the payload type used in `jwt` or `jwt.sign` is defined separately, and the `validator` exists purely for validation, wouldn't it make sense to set the `exp` and `nbf` fields in the `validator` schema to `number`?