### PR TITLE
fix: fix type inconsistencies in JWT payload and improve schema-based inference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ type UnwrapSchema<
 	Fallback = unknown
 > = Schema extends TSchema ? Static<NonNullable<Schema>> : Fallback
 
+type AllowClaimValue = string | number | boolean | null | undefined | AllowClaimValue[] | { [key: string]: AllowClaimValue }
+type ClaimType = Record<string, AllowClaimValue>
+
 /**
  * This interface is a specific, strongly-typed representation of the
  * standard claims found in a JWT payload.
@@ -191,7 +194,7 @@ JWTOption<Name, Schema>) => {
 		}
 	}).decorate(name as Name extends string ? Name : 'jwt', {
 		sign(
-			data: UnwrapSchema<Schema, Record<string, string | number>> &
+			data: UnwrapSchema<Schema, ClaimType> &
 				JWTPayloadSpec
 		) {
 			/**
@@ -311,7 +314,7 @@ JWTOption<Name, Schema>) => {
 		async verify(
 			jwt?: string
 		): Promise<
-			| (UnwrapSchema<Schema, Record<string, string | number>> &
+			| (UnwrapSchema<Schema, ClaimType> &
 					JWTPayloadSpec)
 			| false
 		> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ type UnwrapSchema<
 	Fallback = unknown
 > = Schema extends TSchema ? Static<NonNullable<Schema>> : Fallback
 
+type NormalizedClaim = 'nbf' | 'exp' | 'iat'
+
 type AllowClaimValue = string | number | boolean | null | undefined | AllowClaimValue[] | { [key: string]: AllowClaimValue }
 type ClaimType = Record<string, AllowClaimValue>
 
@@ -69,6 +71,39 @@ export interface JWTPayloadSpec {
 	 *
 	 * @see {@link https://www.rfc-editor.org/rfc/rfc7519#section-4.1.5 RFC7519#section-4.1.5}
 	 */
+	nbf?: number
+
+	/**
+	 * JWT Expiration Time
+	 *
+	 * @see {@link https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4 RFC7519#section-4.1.4}
+	 */
+	exp?: number
+
+	/**
+	 * JWT Issued At
+	 *
+	 * @see {@link https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6 RFC7519#section-4.1.6}
+	 */
+	iat?: number
+}
+
+/**
+ * This interface defines the shape of JWT payload fields that can be
+ * provided as input when creating or signing a token.
+ * 
+ * Unlike `JWTPayloadSpec`, values here may be expressed in more flexible forms,
+ * such as relative time strings or control flags (e.g., `iat: true`).
+ * 
+ * This interface is parsed and normalized by the plugin before becoming part
+ * of the final JWT payload.
+ */
+export interface JWTPayloadInput extends Omit<JWTPayloadSpec, NormalizedClaim> {
+	/**
+	 * JWT Not Before
+	 *
+	 * @see {@link https://www.rfc-editor.org/rfc/rfc7519#section-4.1.5 RFC7519#section-4.1.5}
+	 */
 	nbf?: string | number
 
 	/**
@@ -85,6 +120,7 @@ export interface JWTPayloadSpec {
 	 */
 	iat?: boolean
 }
+
 /**
  * Defines the types for the header parameters of a JWS.
  *
@@ -117,7 +153,7 @@ export interface JWTOption<
 	Name extends string | undefined = 'jwt',
 	Schema extends TSchema | undefined = undefined
 > extends JWTHeaderParameters,
-		JWTPayloadSpec {
+		JWTPayloadInput {
 	/**
 	 * Name to decorate method as
 	 *
@@ -173,10 +209,10 @@ JWTOption<Name, Schema>) => {
 							t.Union([t.String(), t.Array(t.String())])
 						),
 						jti: t.Optional(t.String()),
-						nbf: t.Optional(t.Union([t.String(), t.Number()])),
-						exp: t.Optional(t.Union([t.String(), t.Number()])),
-						iat: t.Optional(t.Union([t.Number(), t.String()]))
-					})
+						nbf: t.Optional(t.Number()),
+						exp: t.Optional(t.Number()),
+						iat: t.Optional(t.Number())
+					}),
 				]),
 				{
 					modules: t.Module({})
@@ -194,8 +230,8 @@ JWTOption<Name, Schema>) => {
 		}
 	}).decorate(name as Name extends string ? Name : 'jwt', {
 		sign(
-			data: UnwrapSchema<Schema, ClaimType> &
-				JWTPayloadSpec
+			data: Omit<UnwrapSchema<Schema, ClaimType>, NormalizedClaim> &
+				JWTPayloadInput
 		) {
 			/**
 			 * @summary Creates the JWS (JSON Web Signature) header object.
@@ -278,7 +314,7 @@ JWTOption<Name, Schema>) => {
 				// Includes all other properties from the data source, both standard and custom.
 				...data
 			} as
-				| Omit<JWTPayloadSpec, 'nbf' | 'exp' | 'iat'>
+				| Omit<JWTPayloadInput, NormalizedClaim>
 				| Record<string, unknown>
 
 			let jwt = new SignJWT({ ...JWTPayload }).setProtectedHeader({
@@ -315,7 +351,7 @@ JWTOption<Name, Schema>) => {
 			jwt?: string
 		): Promise<
 			| (UnwrapSchema<Schema, ClaimType> &
-					JWTPayloadSpec)
+					Omit<JWTPayloadSpec, keyof UnwrapSchema<Schema, {}>>)
 			| false
 		> {
 			if (!jwt) return false
@@ -323,7 +359,7 @@ JWTOption<Name, Schema>) => {
 			try {
 				const data: any = (await jwtVerify(jwt, key)).payload
 
-				if (validator && !validator!.Check(data))
+				if (validator && !validator.Check(data))
 					throw new ValidationError('JWT', validator, data)
 
 				return data


### PR DESCRIPTION
⚠️ This PR depends on #107

This PR addresses an issue where the payload type returned by `verify()` was incorrectly inferred to be the same as the input type passed to `sign()`.

At the same time, it also improves schema-based type inference for JWT payloads — see the examples below for details.

## before

1. Standard claims (nbf, exp, iat) had incorrect types

	```typescript
	const jwt = plugin({
		secret: "x",
	}).decorator.jwt;

	const token = await jwt.sign({});
	const payload = await jwt.verify(token);

	if (payload) {
		// payload.nbf type is `string | number | undefined`
		// payload.exp type is `string | number | undefined`
		// payload.iat type is `boolean | undefined`
	}
	```

2. When a schema is set, type inference does not work properly

	```typescript
	const jwt = plugin({
		secret: "x",
		schema: t.Object({
			aud: t.String(),
			// iat: t.Number(), // if set, to `jwt.sign(data: never): Promise<string>`
		}),
	}).decorator.jwt;

	const token = await jwt.sign({ aud: "tmp" });
	const payload = await jwt.verify(token);

	if (payload) {
		// payload.aud type is `string | (string & string[])`
	}
	```

## after

1. Standard claims are now correctly typed as `number`

	```typescript
	const jwt = plugin({
		secret: "x",
	}).decorator.jwt;

	const token = await jwt.sign({});
	const payload = await jwt.verify(token);

	if (payload) {
		// payload.nbf type is number | undefined
		// payload.exp type is number | undefined
		// payload.iat type is number | undefined
	}
	```

2. When a schema is set, nbf, exp, and iat are applied only to verify(), while other claims have their types properly narrowed.

	```typescript
	const jwt = plugin({
		secret: "x",
		schema: t.Object({
			key: t.String(), // apply sign and verify
			aud: t.String(), // apply sign and verify
			iat: t.Number(), // verify only, `exp` and `nbf` too
		}),
	}).decorator.jwt;

	const token = await jwt.sign({
		key: "value", // ok
		aud: "aud", // ok
		iat: true // ok
	});
	const payload = await jwt.verify(token);

	if (payload) {
		// payload.aud type is `string`
		// payload.iat type is `number`
	}
	```