### PR TITLE
feat: add optional, typed 'options' argument to jwt.verify() and pass to jose jwtVerify() if present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -321,9 +321,12 @@ JWTOption<Name, Schema>) => {
 
 			try {
 				const data: any = (
-					options
-						? await jwtVerify(jwt, key, options)
-						: await jwtVerify(jwt, key)
+					await
+						(options ?
+							jwtVerify(jwt, key, options)
+							:
+							jwtVerify(jwt, key)
+						)
 				).payload
 
 				if (validator && !validator!.Check(data))


### PR DESCRIPTION
This is a small PR to allow optionally passing 'options: JWTVerifyOptions' to jose through jwt.verify().

This allows current implementations to remain unchanged, but opens up support for jose's built-in claims verification without having to interface with jose separately.

I'm a relatively new open-source contributor, so if I'm missing something, please let me know! I'm happy to make any requested changes!