### PR TITLE
doc: add auth middleware example to examples folder

### DIFF
--- a/example/auth-plugin.ts
+++ b/example/auth-plugin.ts
@@ -1,0 +1,28 @@
+import { Elysia, t } from 'elysia'
+import { jwt } from '../src'
+
+const authPlugin = new Elysia({ name: 'authPlugin' })
+	.use(
+		jwt({
+			name: 'jwt',
+			secret: 'top-secret',
+			schema: t.Object({
+				name: t.String()
+			})
+		})
+	)
+	.derive(async ({ cookie: { auth }, jwt }) => {
+		const user = await jwt.verify(auth.value)
+		if (!user) throw new Error('Unauthorized')
+		return { user: user }
+	})
+	.as('scoped')
+
+const protectedRoutes = new Elysia()
+	.use(authPlugin)
+	.get('/me', ({ user }) => `Viewing protected data as ${user.name}`)
+
+const app = new Elysia()
+	.use(protectedRoutes)
+	.get('/public', () => ({ message: 'Public Data' }))
+	.listen(8080)


### PR DESCRIPTION
### Summary

This PR adds an `auth-middleware` example to the examples folder. It demonstrates a common pattern familiar to Express users, where a `verifyJWT` middleware populates the user in the request context.

### Why

Developers migrating from Express often look for equivalent patterns in Elysia, especially around authentication middleware. Having an example in the codebase reduces onboarding friction.

### Proposal

Consider adding this in “Migrating from Express” section in the elysiajs documentation as well, highlighting common patterns such as:

* Auth middleware pattern
* Adding context to the request
* Guarding routes

This example could serve as the reference snippet for that section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added authentication example featuring JWT-based security with cookie-based token verification, protected routes for authenticated users, and public endpoint demonstrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->